### PR TITLE
Refactor OpenAI client handling

### DIFF
--- a/main_code
+++ b/main_code
@@ -27,9 +27,6 @@ from openai import OpenAI
 from dotenv import load_dotenv
 load_dotenv()
 
-import os
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-
 # -----------------------------------------------------------------------------
 # Configuration
 # -----------------------------------------------------------------------------
@@ -57,7 +54,7 @@ def save_heroes(heroes):
     HEROES_FILE.write_text(json.dumps(heroes, indent=2))
 
 def call_chat(messages, model=OPENAI_MODEL_TEXT, temperature=0.9, max_tokens=1024):
-    response = openai.chat.completions.create(
+    response = client.chat.completions.create(
         model=model,
         messages=messages,
         temperature=temperature,
@@ -186,6 +183,7 @@ if not st.session_state["OPENAI_API_KEY"]:
     st.stop()
 
 openai.api_key = st.session_state["OPENAI_API_KEY"]
+client = OpenAI(api_key=st.session_state["OPENAI_API_KEY"])
 
 # Load existing heroes
 heroes = load_heroes()


### PR DESCRIPTION
## Summary
- remove duplicate `import os` and early `OpenAI` initialization
- instantiate `OpenAI` client after API key is provided
- use this client for chat completions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852508760948328b98a655776e5d69e