### PR TITLE
Improve summary tracking

### DIFF
--- a/main_code
+++ b/main_code
@@ -131,10 +131,24 @@ def load_summaries(hero):
         return path.read_text()
     return ""
 
+def load_summary_entries(hero):
+    """Return a list of existing summary entries for the hero."""
+    text = load_summaries(hero).strip()
+    if not text:
+        return []
+    return [entry.strip() for entry in text.split("\n\n") if entry.strip()]
+
+def count_summaries(hero):
+    """Return the number of saved summaries for the hero."""
+    return len(load_summary_entries(hero))
+
 def append_summary(hero, summary_text):
     path = get_summary_file(hero)
+    chapter_num = count_summaries(hero) + 1
+    timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M")
+    entry = f"Chapter {chapter_num} ({timestamp})\n{summary_text}\n\n"
     with open(path, "a", encoding="utf-8") as f:
-        f.write(summary_text + "\n\n")
+        f.write(entry)
 
 def generate_story(hero):
     previous_summaries = load_summaries(hero)
@@ -243,4 +257,6 @@ if st.session_state.get("story_mode"):
 
     st.markdown("---")
     st.markdown("### Previous Summaries")
-    st.write(load_summaries(hero))
+    for entry in load_summary_entries(hero):
+        st.markdown(entry)
+        st.markdown("---")


### PR DESCRIPTION
## Summary
- keep track of chapter count for summaries
- include chapter number and timestamp in stored summaries
- show each previous summary individually

## Testing
- `python3 -m py_compile main_code`

------
https://chatgpt.com/codex/tasks/task_e_685250a044148328aae4e61af849e74f